### PR TITLE
修复BOX的方块无法使用TST触手制作的问题

### DIFF
--- a/src/main/java/com/silvermoon/boxplusplus/common/CommonProxy.java
+++ b/src/main/java/com/silvermoon/boxplusplus/common/CommonProxy.java
@@ -39,12 +39,12 @@ public class CommonProxy {
     }
 
     // postInit "Handle interaction with other mods, complete your setup based on this." (Remove if not needed)
-    public void postInit(FMLPostInitializationEvent event) {}
-
-    // register server commands in this event handler (Remove if not needed)
-    public void serverStarting(FMLServerStartingEvent event) {
+    public void postInit(FMLPostInitializationEvent event) {
         new RecipeLoader().run();
     }
+
+    // register server commands in this event handler (Remove if not needed)
+    public void serverStarting(FMLServerStartingEvent event) {}
 
     public void serverStarted(FMLServerStartedEvent event) {}
 }

--- a/src/main/java/com/silvermoon/boxplusplus/common/loader/RecipeLoader.java
+++ b/src/main/java/com/silvermoon/boxplusplus/common/loader/RecipeLoader.java
@@ -520,7 +520,7 @@ public class RecipeLoader implements Runnable {
             new ItemStack[] { GTModHandler.getModItem(GregTech.ID, "gt.blockmachines", 64, 356),
                 GTModHandler.getModItem(GregTech.ID, "gt.blockmachines", 64, 12735),
                 GTModHandler.getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 64, 3),
-                GTOreDictUnificator.get("gemExquisitePrasiolite", 64),
+                //GTOreDictUnificator.get("gemExquisitePrasiolite", 64),
                 GTModHandler.getModItem(GregTech.ID, "gt.blockcasings8", 8, 14),
                 GTModHandler.getModItem(GregTech.ID, "gt.blockcasings8", 16, 10),
                 GTModHandler.getModItem(GregTech.ID, "gt.blockcasings8", 32, 12),


### PR DESCRIPTION
由于Bartwork过于萨比的加载机制，把物品注册放在postinit中，导致注册配方只能更往后，与TST那边装配线配方转换时机不符，导致box的所有配方都没法在TST的触手无法制作任何BOX的模块与外壳，注销掉Bart的物品后并修改注册时机即可修复问题，未来如果有更好的办法会想办法修复