### PR TITLE
feat: Add new multi-block support for Liquid Level Regulator & AMD AMD Wafer Fab

### DIFF
--- a/src/main/java/com/silvermoon/boxplusplus/common/BoxModule.java
+++ b/src/main/java/com/silvermoon/boxplusplus/common/BoxModule.java
@@ -103,61 +103,57 @@ public class BoxModule {
     }
 
     public static int[] transMachinesToModule(BoxRoutings routing) {
+        String unlocalizedName = routing.RoutingMachine.getUnlocalizedName();
         if (routing.special != 0) {
             if (routing.special > 5402) {
                 return new int[] { 8, 1 };
             }
             return new int[] { 8, 0 };
         }
-        switch (routing.RoutingMachine.getUnlocalizedName()) {
-            case "tile.dire_crafting" -> {
-                return new int[] { 1, 1 };
-            }
-            default -> {
-                return switch (routing.RoutingMachine.getUnlocalizedName()
-                    .substring(17)) {
-                    case "industrialmixer.controller.tier.single", "multimachine.chemicalreactor" -> new int[] { 0, 0 };
-                    case "gtplusplus.autocrafter.multi", "mxrandomlargemolecularassembler" -> new int[] { 1, 0 };
-                    case "multimachine.cracker", "megadistillationtower", "multimachine.adv.distillationtower", "megaoilcracker", "multimachine.distillationtower" -> new int[] {
-                        2, 0 };
-                    case "multimachine.multifurnace", "industrialthermalcentrifuge.controller.tier.single", "industrialarcfurnace.controller.tier.single", "industrialalloysmelter.controller.tier.single" -> new int[] {
-                        3, 0 };
-                    case "industrialmultimachine.controller.tier.single" -> new int[] { 4, 0 };
-                    case "industrialrockcrusher.controller.tier.single", "industrialfluidheater.controller.tier.single", "multimachine.neutroniumcompressor" -> new int[] {
-                        5, 0 };
-                    case "industrialcuttingmachine.controller.tier.01", "industrialmacerator.controller.tier.single", "industrialbender.controller.tier.single", "industrialextruder.controller.tier.single", "industrialwiremill.controller.tier.single", "industrialhammer.controller.tier.single" -> new int[] {
-                        6, 0 };
-                    case "industrialwashplant.controller.tier.single", "industrialsifter.controller.tier.single", "industrialcentrifuge.controller.tier.single", "industrialelectrolyzer.controller.tier.single", "digester", "basicmachine.electromagneticseparator.tier.06" -> new int[] {
-                        7, 0 };
-                    case "industrialcokeoven.controller.tier.single", "multimachine.pyro", "multimachine.vacuumfreezer", "multimachine.adv.industrialfreezer" -> new int[] {
-                        8, 0 };
-                    case "multimachine.assemblyline" -> new int[] { 9, 0 };
-                    case "industrialsalloyamelter.controller.tier.single" -> new int[] { 10, 0 };
-                    case "moleculartransformer.controller.tier.single", "gtpp.multimachine.replicator" -> new int[] { 0,
-                        1 };
-                    case "preciseassembler" -> new int[] { 1, 1 };
-                    case "chemicalplant.controller.tier.single" -> new int[] { 2, 1 };
-                    case "cyclotron.tier.single" -> new int[] { 3, 1 };
-                    case "multimachine.pcbfactory", "circuitassemblyline" -> new int[] { 4, 1 };
-                    case "largefusioncomputer5" -> new int[] { 5, 1 };
-                    case "dissolution_tank", "bw.biovat" -> new int[] { 7, 1 };
-                    case "electricimplosioncompressor", "componentassemblyline", "projectmoduleassemblert3" -> new int[] {
-                        9, 1 };
-                    case "multimachine.plasmaforge", "multimachine.transcendentplasmamixer", "multimachine.nanoforge" -> new int[] {
-                        8, 1 };
-                    case "quantumforcetransformer.controller.tier.single", "frf", "industrialmassfab.controller.tier.single" -> new int[] {
-                        10, 1 };
-                    default -> {
-                        for (MTEMultiBlockBase machine : customerMachineList) {
-                            if (GTUtility.areStacksEqual(machine.getStackForm(1), routing.RoutingMachine, true)) {
-                                yield new int[] { ((IBoxable) machine).getModuleIDSafely(),
-                                    ((IBoxable) machine).isUpdateModule() ? 1 : 0 };
-                            }
-                        }
-                        yield new int[] { 14, 0 };
-                    }
-                };
-            }
+        if ("tile.dire_crafting".equals(unlocalizedName)) {
+            return new int[] { 1, 1 };
         }
+        return switch (unlocalizedName.substring(17)) {
+            case "industrialmixer.controller.tier.single", "multimachine.chemicalreactor" -> new int[] { 0, 0 };
+            case "gtplusplus.autocrafter.multi", "mxrandomlargemolecularassembler" -> new int[] { 1, 0 };
+            case "multimachine.cracker", "megadistillationtower", "multimachine.adv.distillationtower", "megaoilcracker", "multimachine.distillationtower" -> new int[] {
+                2, 0 };
+            case "multimachine.multifurnace", "industrialthermalcentrifuge.controller.tier.single", "industrialarcfurnace.controller.tier.single", "industrialalloysmelter.controller.tier.single" -> new int[] {
+                3, 0 };
+            case "industrialmultimachine.controller.tier.single", "multimachine.basiccompressor", "multimachine.lathe", "multimachine.electromagneticseparator", "multimachine.extractor", "multimachine.fluidextractor", "multimachine.engraver", "multimachine.autoclave", "multimachine.solidifier" -> new int[] {
+                4, 0 };
+            case "industrialrockcrusher.controller.tier.single", "industrialfluidheater.controller.tier.single", "multimachine.neutroniumcompressor" -> new int[] {
+                5, 0 };
+            case "industrialcuttingmachine.controller.tier.01", "industrialmacerator.controller.tier.single", "industrialbender.controller.tier.single", "industrialextruder.controller.tier.single", "industrialwiremill.controller.tier.single", "industrialhammer.controller.tier.single" -> new int[] {
+                6, 0 };
+            case "industrialwashplant.controller.tier.single", "industrialsifter.controller.tier.single", "industrialcentrifuge.controller.tier.single", "industrialelectrolyzer.controller.tier.single", "digester", "basicmachine.electromagneticseparator.tier.06" -> new int[] {
+                7, 0 };
+            case "industrialcokeoven.controller.tier.single", "multimachine.pyro", "multimachine.vacuumfreezer", "multimachine.adv.industrialfreezer" -> new int[] {
+                8, 0 };
+            case "multimachine.assemblyline" -> new int[] { 9, 0 };
+            case "industrialsalloyamelter.controller.tier.single" -> new int[] { 10, 0 };
+            case "moleculartransformer.controller.tier.single", "gtpp.multimachine.replicator" -> new int[] { 0, 1 };
+            case "preciseassembler" -> new int[] { 1, 1 };
+            case "chemicalplant.controller.tier.single" -> new int[] { 2, 1 };
+            case "cyclotron.tier.single" -> new int[] { 3, 1 };
+            case "multimachine.pcbfactory", "circuitassemblyline" -> new int[] { 4, 1 };
+            case "largefusioncomputer5" -> new int[] { 5, 1 };
+            case "dissolution_tank", "bw.biovat" -> new int[] { 7, 1 };
+            case "electricimplosioncompressor", "componentassemblyline", "projectmoduleassemblert3" -> new int[] { 9,
+                1 };
+            case "multimachine.plasma forge", "multimachine.transcendentplasmamixer", "multimachine.nanoforge" -> new int[] {
+                8, 1 };
+            case "quantumforcetransformer.controller.tier.single", "frf", "industrialmassfab.controller.tier.single" -> new int[] {
+                10, 1 };
+            default -> {
+                for (MTEMultiBlockBase machine : customerMachineList) {
+                    if (GTUtility.areStacksEqual(machine.getStackForm(1), routing.RoutingMachine, true)) {
+                        yield new int[] { ((IBoxable) machine).getModuleIDSafely(),
+                            ((IBoxable) machine).isUpdateModule() ? 1 : 0 };
+                    }
+                }
+                yield new int[] { 14, 0 };
+            }
+        };
     }
 }

--- a/src/main/java/com/silvermoon/boxplusplus/common/BoxModule.java
+++ b/src/main/java/com/silvermoon/boxplusplus/common/BoxModule.java
@@ -113,9 +113,6 @@ public class BoxModule {
             case "tile.dire_crafting" -> {
                 return new int[] { 1, 1 };
             }
-            case "tile.neutronium_compressor" -> {
-                return new int[] { 5, 0 };
-            }
             default -> {
                 return switch (routing.RoutingMachine.getUnlocalizedName()
                     .substring(17)) {
@@ -126,7 +123,7 @@ public class BoxModule {
                     case "multimachine.multifurnace", "industrialthermalcentrifuge.controller.tier.single", "industrialarcfurnace.controller.tier.single", "industrialalloysmelter.controller.tier.single" -> new int[] {
                         3, 0 };
                     case "industrialmultimachine.controller.tier.single" -> new int[] { 4, 0 };
-                    case "industrialrockcrusher.controller.tier.single", "industrialfluidheater.controller.tier.single" -> new int[] {
+                    case "industrialrockcrusher.controller.tier.single", "industrialfluidheater.controller.tier.single", "multimachine.neutroniumcompressor" -> new int[] {
                         5, 0 };
                     case "industrialcuttingmachine.controller.tier.01", "industrialmacerator.controller.tier.single", "industrialbender.controller.tier.single", "industrialextruder.controller.tier.single", "industrialwiremill.controller.tier.single", "industrialhammer.controller.tier.single" -> new int[] {
                         6, 0 };

--- a/src/main/java/com/silvermoon/boxplusplus/util/BoxRoutings.java
+++ b/src/main/java/com/silvermoon/boxplusplus/util/BoxRoutings.java
@@ -268,27 +268,6 @@ public class BoxRoutings {
                             }
                             return;
                         }
-                        // Really? You add neutronium compressor?
-                        if (inputBus.getStackInSlot(i)
-                            .getUnlocalizedName()
-                            .equals("tile.neutronium_compressor")) {
-                            for (ItemStack item : allInputItems) {
-                                ItemStack out = fox.spiteful.avaritia.crafting.CompressorManager.getOutput(item);
-                                if (out != null) {
-                                    ItemStack in = item.copy();
-                                    in.stackSize = fox.spiteful.avaritia.crafting.CompressorManager.getCost(item);
-                                    ItemStack machine = inputBus.getStackInSlot(i)
-                                        .copy();
-                                    machine.stackSize = 1;
-                                    box.routingMap
-                                        .add(new BoxRoutings(in, out, machine, TierEU.RECIPE_ZPM, TickTime.MINUTE));
-                                    box.routingStatus = 0;
-                                    return;
-                                }
-                            }
-                            box.routingStatus = 3;
-                            return;
-                        }
                         // Extreme Craft Table
                         if (inputBus.getStackInSlot(i)
                             .getUnlocalizedName()


### PR DESCRIPTION
## 1. 修复液位调节器不支持多方块的中子态素压缩机问题

- 移除无尽贪婪的中子态素压缩机代码
- 将多方块中子态素压缩机添加进液位调节器模块支持机器

**由于黑洞压缩机和中子态素压缩机同属一个配方组，所以也能跑黑洞配方**
> 但是我都用盒了，谁在意这些🤣

## 2. AMD晶圆厂模块支持大型加工厂替代机器

**在GTNH2.7后，大型加工厂（以下称为九合一）大部分出了替代的多方块机器，导致从nei导入的默认机器为新加入的机器，但是AMD模块中的支持的机器仍然是九合一。**

### 九合一替代方案

| Machine Type | UnlocalizedName | New Multi-Block Machine Name |
| --- | --- | --- |
| 压缩 | gt.blockmachines.multimachine.basiccompressor | 大型电动压缩机 |
| 车床 | gt.blockmachines.multimachine.lathe | 工业精密车床 |
| 两级磁化 | gt.blockmachines.multimachine.electromagneticseparator | 磁通量效应监视器 |
| 发酵槽 | gt.blockmachines.industrialmultimachine.controller.tier.single | 九合一（暂无替代） |
| 流体提取 | gt.blockmachines.multimachine.extractor | 剖析提取装置 |
| 提取 | gt.blockmachines.multimachine.fluidextractor | 大型流体提取机 |
| 光刻 | gt.blockmachines.multimachine.engraver | 高强度激光蚀刻机 |
| 高压釜 | gt.blockmachines.multimachine.autoclave | 工业高压釜 |
| 固化 | gt.blockmachines.multimachine.solidifier | 流体塑形机 |

> 以下配方虽然从nei导入的机器仍是九合一，但为了兼容以后版本，将其替换为了对应的多方块机器名。
> - 提取机
> - 激光蚀刻机

---

This pull request makes several changes to the `BoxModule` and `BoxRoutings` classes in the `com.silvermoon.boxplusplus` package to improve code readability and maintainability by refactoring and removing redundant code. The most important changes include refactoring the `transMachinesToModule` method, removing unnecessary code related to the `neutronium_compressor`, and making minor formatting adjustments.

Refactoring and code improvements:

* [`src/main/java/com/silvermoon/boxplusplus/common/BoxModule.java`](diffhunk://#diff-4490deeb0f47b5212032f2ec7112b651bf8e069d61404cc8bafbb76b18cbc1bfR106-R125): Refactored the `transMachinesToModule` method to use a local variable `unlocalizedName` and simplified the switch-case structure for better readability. [[1]](diffhunk://#diff-4490deeb0f47b5212032f2ec7112b651bf8e069d61404cc8bafbb76b18cbc1bfR106-R125) [[2]](diffhunk://#diff-4490deeb0f47b5212032f2ec7112b651bf8e069d61404cc8bafbb76b18cbc1bfL139-R143) [[3]](diffhunk://#diff-4490deeb0f47b5212032f2ec7112b651bf8e069d61404cc8bafbb76b18cbc1bfL165-L166)

Code removal:

* [`src/main/java/com/silvermoon/boxplusplus/util/BoxRoutings.java`](diffhunk://#diff-f7b0872f904e96f4c7dd500efb2160e114da7a4eae69d92d43ba43d25c492836L271-L291): Removed unnecessary code related to handling the `neutronium_compressor` in the `checkRouting` method.

Formatting adjustments:

* [`src/main/java/com/silvermoon/boxplusplus/common/BoxModule.java`](diffhunk://#diff-4490deeb0f47b5212032f2ec7112b651bf8e069d61404cc8bafbb76b18cbc1bfL139-R143): Made minor formatting adjustments to align the code properly. [[1]](diffhunk://#diff-4490deeb0f47b5212032f2ec7112b651bf8e069d61404cc8bafbb76b18cbc1bfL139-R143) [[2]](diffhunk://#diff-4490deeb0f47b5212032f2ec7112b651bf8e069d61404cc8bafbb76b18cbc1bfL165-L166)